### PR TITLE
fix col, off by one

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -33,7 +33,7 @@ module.exports = function Lexer (input, options) {
         location: {
           filename: options.filename,
           line: line,
-          col: col,
+          col: col + 1,
           src: input
         }
       })


### PR DESCRIPTION
reporter is marking col `47` as containing the error, but if after checking my ruler and counting the chars, the correct col is 48.
```
Error: SugarmlError: Cannot parse character "'"
Location: /Users/henrysnopek/dev/amazing/project/views/_nav.sml:9:47

   8. |     #overlay: ul.categories
 > 9. |       each(loop='cat in Object.keys(categories)')
      |                                               ^
```