### PR TITLE
Added unbuffered comments similar to pugjs

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -300,7 +300,11 @@ module.exports = function Lexer (input, options) {
       next(); next()
 
       // if there is a space, move past that
-      if (char.match(/\s/)) next()
+      if (char.match(/\s/)) {
+        next()
+      } else if (char === '-') {
+        return
+      }
 
       // grab the comment body
       const comment = collectUntil('\n')


### PR DESCRIPTION
A first shot at adding unbuffered comments. comments beginning with
`//-` will not be included in the exported markup, as opposed to
comments of the form `//`, which will be included in exported markup.