### PR TITLE
remove unused "parseOptions" option, and add default options in lexer

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 const lex = require('./lexer')
 const parse = require('./parser')
 
-module.exports = function SugarMLParser(input, parseOptions, options) {
+module.exports = function SugarMLParser(input, options) {
   return parse(lex(input, options))
 }
 

--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -1,6 +1,6 @@
 const SugarmlError = require('./error')
 
-module.exports = function Lexer(input, options) {
+module.exports = function Lexer(input, options = {}) {
   let line = 1
   let col = 1
   let current = 0


### PR DESCRIPTION
What I did:
- parseOptions in `lib/index.js` was unusued, removed it
- added default empty object as an options to lexer (a la `reshape/parser`)

Why:
Reshape by default calls this function with `(input, opts.parseOptions, opts)`. In none of the tests was `parseOptions` defined, so error tests kept failing by trying to access `undefined.filename` when generating errors. Looking at `reshape/parser`, I realised that lexer has just to explicitly start with empty config if none is given.